### PR TITLE
fix: fix mock get_entry signature

### DIFF
--- a/mocks/src/lib.rs
+++ b/mocks/src/lib.rs
@@ -31,7 +31,7 @@ pub struct FPOContract {}
 #[near_bindgen]
 impl FPOContract {
   /// Returns all data associated with a price pair by a provider
-  pub fn get_entry(&self, pair: String, _provider: AccountId) -> Option<PriceEntry> {
+  pub fn get_entry(&self, pair: String, provider: AccountId) -> Option<PriceEntry> {
     env::log(format!("get_entry OK").as_bytes());
     match &*pair {
       "NEAR/USD" => Some(PriceEntry {

--- a/tests/sim/main.rs
+++ b/tests/sim/main.rs
@@ -152,7 +152,6 @@ fn test_transfer_usd_near() {
         ),
         deposit = transfer_amount
     );
-    // TODO this call fails
     result.assert_success();
 
     // println!(


### PR DESCRIPTION
Fixes failing unit test test_transfer_usd_near.
The root cause was get_entry method signature out of sync in conversion
proxy contract and in mock fpo contract.

It can be easily detected by and reported by removing the `.then` part
in the conversion_proxy/src/lib.rs#L107-116 . After doing that you can
use println in the unit test to print the outcome and see the reason of
the fail for the original root cause.