### PR TITLE
fix: precision issue for big amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,8 @@ cargo test
 
 ## Integration tests
 
-First build the mock contract.
-
 ```
-cd contracts/mocks
-./build.sh
-```
-
-Then test.
-
-```
-cd contracts
-cargo test
+./test.sh
 ```
 
 ## Deploying contract

--- a/conversion_proxy/src/lib.rs
+++ b/conversion_proxy/src/lib.rs
@@ -263,9 +263,10 @@ impl ConversionProxy {
         let conversion_rate = u128::from(rate.price);
         let decimals = u32::from(rate.decimals);
         let main_payment =
-            Balance::from(amount) * ONE_NEAR / (ONE_FIAT * conversion_rate / 10u128.pow(decimals));
-        let fee_payment = Balance::from(fee_amount) * ONE_NEAR
-            / (ONE_FIAT * conversion_rate / 10u128.pow(decimals));
+            Balance::from(amount) * ONE_NEAR * 10u128.pow(decimals) / conversion_rate / ONE_FIAT;
+        let fee_payment = Balance::from(fee_amount) * ONE_NEAR * 10u128.pow(decimals)
+            / conversion_rate
+            / ONE_FIAT;
 
         let total_payment = main_payment + fee_payment;
         // Check deposit

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,7 +15,7 @@ while getopts ":a:ph" opt; do
       echo ""
       echo "Options:"
       echo "  -p              : for prod deployment"
-      echo "  -a [account_id] : to overrirde \$ACCOUNT_ID"
+      echo "  -a [account_id] : to override \$ACCOUNT_ID"
       exit 0
       ;;
     p)
@@ -46,4 +46,4 @@ printf "ACCOUNT_ID=%s\n" "$ACCOUNT_ID"
 near deploy -f --wasmFile ./out/conversion_proxy.wasm \
   --accountId $ACCOUNT_ID \
   --initFunction new  \
-  --initArgs '{"oracle_account_id": "$oracle_account_id", "provider_account_id": "$provider_account_id"}'
+  --initArgs '{"oracle_account_id": "'$oracle_account_id'", "provider_account_id": "'$provider_account_id'"}'

--- a/mocks/src/lib.rs
+++ b/mocks/src/lib.rs
@@ -34,8 +34,8 @@ impl FPOContract {
     env::log(format!("get_entry OK").as_bytes());
     match &*pair {
       "NEAR/USD" => Some(PriceEntry {
-        // 1 USD = 123 NEAR, 10 nanoseconds ago
-        price: U128::from(123000000),
+        // 1 NEAR = 1.234 USD, 10 nanoseconds ago
+        price: U128::from(1234000),
         decimals: 6,
         last_update: env::block_timestamp() - 10,
       }),
@@ -83,7 +83,7 @@ mod tests {
     testing_env!(context);
     let contract = FPOContract::default();
     if let Some(result) = contract.get_entry("NEAR/USD".to_string(), "any".to_string()) {
-      assert_eq!(result.price, U128::from(123000000));
+      assert_eq!(result.price, U128::from(1234000));
       assert_eq!(result.decimals, 6);
     } else {
       panic!("NEAR/USD mock returned None")

--- a/patch-deploy.sh
+++ b/patch-deploy.sh
@@ -13,7 +13,7 @@ while getopts ":a:ph" opt; do
       echo ""
       echo "Options:"
       echo "  -p              : for prod deployment"
-      echo "  -a [account_id] : to overrirde \$ACCOUNT_ID"
+      echo "  -a [account_id] : to override \$ACCOUNT_ID"
       exit 0
       ;;
     p)

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
 cd mocks/
 ./build.sh
 cd ..
+./build.sh
 cargo test -- --nocapture


### PR DESCRIPTION
The conversion was not truncated properly, leaving us with a precision of only 0.01, visible for big amounts.
This fix is already deployed on mainnet and testnet, tested [here ](https://explorer.testnet.near.org/transactions/83gJQXmGE2UCu3Y1ZQYgHrKUv2xYKhD4r8KGh6DBk8H5)and [there](https://nearblocks.io/txns/GHxwk1u6UPtpKd2SP16uvVAmuj6negV46J88mRUx56WC#execution).