### PR TITLE
chore: use log macro

### DIFF
--- a/conversion_proxy/src/lib.rs
+++ b/conversion_proxy/src/lib.rs
@@ -3,7 +3,7 @@ use near_sdk::json_types::{ValidAccountId, U128, U64};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::serde_json::json;
 use near_sdk::{
-    env, near_bindgen, serde_json, AccountId, Balance, Gas, Promise, PromiseResult, Timestamp,
+    env, near_bindgen, serde_json, AccountId, Balance, Gas, Promise, PromiseResult, Timestamp, log,
 };
 
 near_sdk::setup_alloc!();
@@ -216,12 +216,9 @@ impl ConversionProxy {
             );
             true
         } else {
-            env::log(
-                format!(
-                    "Failed to transfer to account {}. Returning attached deposit of {} to {}",
-                    payment_address, deposit.0, predecessor_account_id
-                )
-                .as_bytes(),
+            log!(
+                "Failed to transfer to account {}. Returning attached deposit of {} to {}",
+                payment_address, deposit.0, predecessor_account_id
             );
             Promise::new(predecessor_account_id).transfer(deposit.into());
             false

--- a/fungible_conversion_proxy/src/lib.rs
+++ b/fungible_conversion_proxy/src/lib.rs
@@ -3,7 +3,7 @@ use near_sdk::json_types::{Base64VecU8, ValidAccountId, U128, U64};
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::serde_json::json;
 use near_sdk::{
-    env, near_bindgen, serde_json, AccountId, Balance, Gas, Promise, PromiseResult, Timestamp,
+    env, near_bindgen, serde_json, AccountId, Balance, Gas, Promise, PromiseResult, Timestamp, log,
 };
 near_sdk::setup_alloc!();
 
@@ -291,11 +291,9 @@ impl FungibleConversionProxy {
             );
             change.0.to_string() // return change for `ft_resolve_transfer` on the token contract
         } else {
-            env::log(
-                format!(
+            log!(
                     "Failed to transfer to account {}. Returning attached deposit of {} of token {} to {}",
-                    args.to, deposit.0, token_address, payer)
-                .as_bytes(),
+                    args.to, deposit.0, token_address, payer
             );
             deposit.0.to_string() // return full amount for `ft_resolve_transfer` on the token contract
         }

--- a/fungible_proxy/src/lib.rs
+++ b/fungible_proxy/src/lib.rs
@@ -1,5 +1,6 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::json_types::{ValidAccountId, U128};
+use near_sdk::log;
 use near_sdk::serde::{Deserialize, Serialize};
 use near_sdk::serde_json::json;
 use near_sdk::{
@@ -180,12 +181,7 @@ impl FungibleProxy {
         } else {
              // return full amount for `ft_resolve_transfer` on the token contract
             let change = (amount.0 + args.fee_amount.0).to_string();
-            env::log(
-                format!(
-                    "Failed to transfer to account {}. Returning attached amount of {} of token {} to {}",
-                    args.to, change, token_address, payer)
-                .as_bytes(),
-            );
+            log!("Failed to transfer to account {}. Returning attached amount of {} of token {} to {}", args.to, change, token_address, payer);
             change
         }
     }

--- a/mocks/src/fpo_oracle_mock.rs
+++ b/mocks/src/fpo_oracle_mock.rs
@@ -29,7 +29,6 @@ pub struct FPOContract {}
 impl FPOContract {
     #[allow(unused_variables)]
     pub fn get_entry(&self, pair: String, provider: AccountId) -> Option<PriceEntry> {
-        env::log(format!("get_entry OK").as_bytes());
         match &*pair {
             "NEAR/USD" => Some(PriceEntry {
                 // 1 NEAR = 1.234 USD, 10 nanoseconds ago

--- a/mocks/src/fungible_token_mock.rs
+++ b/mocks/src/fungible_token_mock.rs
@@ -66,12 +66,9 @@ impl FungibleTokenContract {
             U128::from(old_sender_balance.0 - amt),
         );
         self.set_balance(receiver_id, U128::from(old_receiver_balance.0 + amt));
-
-        env::log(format!("ft_transfer OK").as_bytes());
     }
 
     pub fn ft_metadata(&self) -> Option<FungibleTokenMetadata> {
-        env::log(format!("ft_metadata OK").as_bytes());
         Some(FungibleTokenMetadata {
             spec: "ft-1.0.0".into(),
             name: "USD Coin".into(),

--- a/tests/sim/fungible_proxy.rs
+++ b/tests/sim/fungible_proxy.rs
@@ -219,7 +219,7 @@ fn test_transfer_receiver_send_failed() {
     );
     result.assert_success();
     assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    assert_eq!(result.logs()[0], format!("Failed to transfer to account bob. Returning attached amount of 500000000 of token mockedft to alice"));
+    assert_eq!(result.logs()[0], "Failed to transfer to account bob. Returning attached amount of 500000000 of token mockedft to alice");
 
     // The mocked fungible token does not handle change
     let change = result.unwrap_json::<String>().parse::<u128>().unwrap();
@@ -259,7 +259,7 @@ fn test_transfer_fee_receiver_send_failed() {
     );
     result.assert_success();
     assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    assert_eq!(result.logs()[0], format!("Failed to transfer to account bob. Returning attached amount of 500000000 of token mockedft to alice"));
+    assert_eq!(result.logs()[0], "Failed to transfer to account bob. Returning attached amount of 500000000 of token mockedft to alice");
 
     // The mocked fungible token does not handle change
     let change = result.unwrap_json::<String>().parse::<u128>().unwrap();


### PR DESCRIPTION
As requested in #12 https://github.com/RequestNetwork/near-contracts/pull/12#discussion_r1163175251

This change enforces the use of the `log!` macro.