### PR TITLE
chore: cache workflow builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,16 @@ jobs:
     - name: Rust downgrade
       run: rustup default 1.67.0
     - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      id: cache
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm32-unknown-unknown target
       run: rustup target add wasm32-unknown-unknown
     - name: Build contracts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,7 @@ jobs:
     - name: Build contracts
       run: ./build.sh
     - name: Build mocks
-      working-directory: ./mocks
-      run: ./build.sh
+      run: ./mocks/build.sh
     - name: Unit and Integration Tests
       run: cargo test --all
 

--- a/mocks/build.sh
+++ b/mocks/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-RUSTFLAGS='-C link-arg=-s' cargo build --target wasm32-unknown-unknown
+RUSTFLAGS='-C link-arg=-s' cargo build -p mocks --target wasm32-unknown-unknown


### PR DESCRIPTION
This caches the builds of contracts and mocks in order to save up to 3m30sec of PR check execution in current state.

Pending:
- #16 