### PR TITLE
chore: utils to refund and not panic

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -66,7 +66,7 @@ else
   
   if [ "$contract_name" = "conversion_proxy" ]; then
     if [ "$NEAR_ENV" = "mainnet" ]; then
-      feed_parser="switchboard-v2.mainnet";
+      feed_parser="switchboard-v2.near";
       feed_address="C3p8SSWQS8j1nx7HrzBBphX5jZcS1EY28EJ5iwjzSix2";
     else
       feed_parser="switchboard-v2.testnet";

--- a/deploy.sh
+++ b/deploy.sh
@@ -60,7 +60,7 @@ printf "Deploying %s on NEAR_ENV=%s with ACCOUNT_ID=%s (patch=%s)\n\n" "$contrac
 
 if [ "$contract_name" = "fungible_proxy" ]; then
   set -x
-  near deploy -f --wasmFile ./target/wasm32-unknown-unknown/release/$contract_name.wasm \
+  NEAR_ENV=$NEAR_ENV near deploy -f --wasmFile ./target/wasm32-unknown-unknown/release/$contract_name.wasm \
    --accountId $ACCOUNT_ID
 else
   
@@ -84,7 +84,7 @@ else
     --initArgs $initArgs";
   fi
   set -x
-  near deploy -f --wasmFile ./target/wasm32-unknown-unknown/release/$contract_name.wasm \
+  NEAR_ENV=$NEAR_ENV near deploy -f --wasmFile ./target/wasm32-unknown-unknown/release/$contract_name.wasm \
     --accountId $ACCOUNT_ID \
     $initParams
 fi

--- a/tests/sim/conversion_proxy.rs
+++ b/tests/sim/conversion_proxy.rs
@@ -344,7 +344,7 @@ fn test_outdated_rate() {
         ),
         deposit = transfer_amount
     );
-    result.assert_one_promise_error("Conversion rate too old");
+    result.assert_success_one_log("Conversion rate too old");
 
     assert_eq!(
         initial_proxy_balance,

--- a/tests/sim/conversion_proxy.rs
+++ b/tests/sim/conversion_proxy.rs
@@ -268,7 +268,6 @@ fn test_transfer_with_wrong_feed_address() {
         "Alice should not spend NEAR on a wrong feed address payment.",
     );
 
-    // The contract's balance is slightly impacted by execution, hence we divide by 1 NEAR
     assert_eq!(
         proxy.account().unwrap().amount,
         initial_contract_balance,

--- a/tests/sim/conversion_proxy.rs
+++ b/tests/sim/conversion_proxy.rs
@@ -150,7 +150,7 @@ fn test_transfer_with_invalid_reference_length() {
         ),
         deposit = transfer_amount
     );
-    assert_one_promise_error(result.clone(), "Incorrect payment reference length");
+    result.assert_one_promise_error("Incorrect payment reference length");
 
     // Check Alice balance
     assert_eq!(
@@ -181,10 +181,7 @@ fn test_transfer_with_wrong_currency() {
         ),
         deposit = transfer_amount
     );
-    assert_one_promise_error(
-        result,
-        "Only payments denominated in USD are implemented for now",
-    );
+    result.assert_one_promise_error("Only payments denominated in USD are implemented for now");
 }
 
 #[test]
@@ -210,9 +207,7 @@ fn test_transfer_with_low_deposit() {
         ),
         deposit = transfer_amount
     );
-    result.assert_success();
-    assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    assert!(result.logs()[0].contains("Deposit too small for payment"));
+    result.assert_success_one_log("Deposit too small for payment");
 
     assert_eq!(
         alice.account().unwrap().amount,
@@ -220,6 +215,60 @@ fn test_transfer_with_low_deposit() {
         "Alice should not spend NEAR on a failed payment.",
     );
 
+    assert_eq!(
+        proxy.account().unwrap().amount,
+        initial_contract_balance,
+        "Contract's balance should be unchanged"
+    );
+    assert_eq!(
+        builder.account().unwrap().amount,
+        initial_bob_balance,
+        "Builder's balance should be unchanged"
+    );
+}
+
+#[test]
+fn test_transfer_with_wrong_feed_address() {
+    let (alice, bob, builder, proxy, root) = init();
+
+    let result = call!(alice, proxy.get_encoded_feed_address());
+    result.assert_success();
+
+    let result = call!(
+        root,
+        proxy.set_feed_address(&"7igqhpGQ8xPpyjQ4gMHhXRvtZcrKSGJkdKDJYBiPQgcb".to_string())
+    );
+    result.assert_success();
+
+    let initial_alice_balance = alice.account().unwrap().amount;
+    let initial_bob_balance = bob.account().unwrap().amount;
+    let initial_contract_balance = proxy.account().unwrap().amount;
+    let transfer_amount = to_yocto("100000");
+    let payment_address = bob.account_id().try_into().unwrap();
+    let fee_address = builder.account_id().try_into().unwrap();
+
+    let result = call!(
+        alice,
+        proxy.transfer_with_reference(
+            PAYMENT_REF.into(),
+            payment_address,
+            U128::from(2000000),
+            USD.into(),
+            fee_address,
+            U128::from(0),
+            U64::from(0)
+        ),
+        deposit = transfer_amount
+    );
+    result.assert_success_one_log("ERR_FAILED_ORACLE_FETCH");
+
+    assert_eq!(
+        alice.account().unwrap().amount,
+        initial_alice_balance,
+        "Alice should not spend NEAR on a wrong feed address payment.",
+    );
+
+    // The contract's balance is slightly impacted by execution, hence we divide by 1 NEAR
     assert_eq!(
         proxy.account().unwrap().amount,
         initial_contract_balance,
@@ -295,9 +344,7 @@ fn test_outdated_rate() {
         ),
         deposit = transfer_amount
     );
-    result.assert_success();
-    assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    assert!(result.logs()[0].contains("Conversion rate too old"));
+    result.assert_one_promise_error("Conversion rate too old");
 
     assert_eq!(
         initial_proxy_balance,

--- a/tests/sim/fungible_conversion_proxy.rs
+++ b/tests/sim/fungible_conversion_proxy.rs
@@ -238,7 +238,7 @@ fn test_transfer_not_enough() {
         ft_contract.user_account,
         proxy.ft_on_transfer(alice.account_id(), send_amt.0.to_string(), msg)
     );
-    assert_one_promise_error(result, "Deposit too small")
+    result.assert_one_promise_error("Deposit too small");
 }
 
 #[test]
@@ -410,5 +410,5 @@ fn test_outdated_rate() {
         ft_contract.user_account,
         proxy.ft_on_transfer(alice.account_id(), send_amt.0.to_string(), msg)
     );
-    assert_one_promise_error(result, "Conversion rate too old");
+    result.assert_one_promise_error("Conversion rate too old");
 }

--- a/tests/sim/fungible_proxy.rs
+++ b/tests/sim/fungible_proxy.rs
@@ -144,18 +144,17 @@ fn test_transfer() {
         ft_contract.user_account,
         proxy.ft_on_transfer(alice.account_id(), send_amt.0.to_string(), args.into())
     );
-    result.assert_success();
-    assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    let expected_log = json!({
-        "amount": "498000000", // 500 USDC.e - 2 USDC.e fee
-        "token_address": "mockedft",
-        "fee_address": "builder",
-        "fee_amount": "2000000",
-        "payment_reference": "abc7c8bb1234fd11",
-        "to": "bob",
-    })
-    .to_string();
-    assert_eq!(result.logs()[0], expected_log);
+    result.assert_success_one_log(
+        &json!({
+            "amount": "498000000", // 500 USDC.e - 2 USDC.e fee
+            "token_address": "mockedft",
+            "fee_address": "builder",
+            "fee_amount": "2000000",
+            "payment_reference": "abc7c8bb1234fd11",
+            "to": "bob",
+        })
+        .to_string(),
+    );
 
     // The mocked fungible token does not handle change
     let change = result.unwrap_json::<String>().parse::<u128>().unwrap();
@@ -184,7 +183,7 @@ fn transfer_less_than_fee_amount() {
         ft_contract.user_account,
         proxy.ft_on_transfer(alice.account_id(), send_amt.0.to_string(), args.into())
     );
-    assert_one_promise_error(result, "amount smaller than fee_amount")
+    result.assert_one_promise_error("amount smaller than fee_amount");
 }
 
 #[test]
@@ -210,9 +209,7 @@ fn test_transfer_receiver_send_failed() {
         ft_contract.user_account,
         proxy.ft_on_transfer(alice.account_id(), send_amt.0.to_string(), args.into())
     );
-    result.assert_success();
-    assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    assert_eq!(result.logs()[0], "Transfer failed to bob or builder. Returning attached amount of 500000000 of token mockedft to alice");
+    result.assert_success_one_log("Transfer failed to bob or builder. Returning attached amount of 500000000 of token mockedft to alice");
 
     // The mocked fungible token does not handle change
     let change = result.unwrap_json::<String>().parse::<u128>().unwrap();
@@ -250,9 +247,7 @@ fn test_transfer_fee_receiver_send_failed() {
         ft_contract.user_account,
         proxy.ft_on_transfer(alice.account_id(), send_amt.0.to_string(), args.into())
     );
-    result.assert_success();
-    assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    assert_eq!(result.logs()[0], "Transfer failed to bob or builder. Returning attached amount of 500000000 of token mockedft to alice");
+    result.assert_success_one_log("Transfer failed to bob or builder. Returning attached amount of 500000000 of token mockedft to alice");
 
     // The mocked fungible token does not handle change
     let change = result.unwrap_json::<String>().parse::<u128>().unwrap();
@@ -284,18 +279,17 @@ fn test_transfer_zero_usd() {
         ft_contract.user_account,
         proxy.ft_on_transfer(alice.account_id(), send_amt.0.to_string(), args.into())
     );
-    result.assert_success();
-    assert_eq!(result.logs().len(), 1, "Wrong number of logs");
-    let expected_log = json!({
-        "amount": "0",
-        "token_address": "mockedft",
-        "fee_address": "builder",
-        "fee_amount": "0",
-        "payment_reference": "abc7c8bb1234fd12",
-        "to": "bob",
-    })
-    .to_string();
-    assert_eq!(result.logs()[0], expected_log);
+    result.assert_success_one_log(
+        &json!({
+            "amount": "0",
+            "token_address": "mockedft",
+            "fee_address": "builder",
+            "fee_amount": "0",
+            "payment_reference": "abc7c8bb1234fd12",
+            "to": "bob",
+        })
+        .to_string(),
+    );
 
     assert_unchanged_balance(alice, alice_balance_before, &ft_contract, "Alice");
     assert_unchanged_balance(bob, bob_balance_before, &ft_contract, "Bob");


### PR DESCRIPTION
Some nice refactoring related to replacing `panic!` with logs instead when the issuer should be refunded.

chore: refactoring of test utils with `impl ExecutionResultAssertion for ExecutionResult`
chore: refactoring of how "not to panic", with `refund_then_log()`, since we don't know how to do it after a refund
chore: added `test_transfer_with_wrong_feed_address`
fix: deployment script should set the `NEAR_ENV` param