### PR TITLE
fix: conversion should not overflow

### DIFF
--- a/conversion_proxy/src/lib.rs
+++ b/conversion_proxy/src/lib.rs
@@ -330,7 +330,7 @@ impl ConversionProxy {
                 precision * 10,
             );
         }
-        let main_payment = main_payment / conversion_rate * precision;
+        let main_payment = main_payment * precision / conversion_rate;
         return main_payment;
     }
 

--- a/conversion_proxy/src/lib.rs
+++ b/conversion_proxy/src/lib.rs
@@ -322,7 +322,6 @@ impl ConversionProxy {
     ) -> u128 {
         let (main_payment, flag) = (Balance::from(amount) * ONE_NEAR / ONE_FIAT / precision)
             .overflowing_mul(10u128.pow(u32::from(decimals)));
-        let main_payment = main_payment / conversion_rate * precision;
         if flag {
             return Self::apply_conversion_with_precision(
                 amount,
@@ -331,6 +330,7 @@ impl ConversionProxy {
                 precision * 10,
             );
         }
+        let main_payment = main_payment / conversion_rate * precision;
         return main_payment;
     }
 

--- a/conversion_proxy/src/lib.rs
+++ b/conversion_proxy/src/lib.rs
@@ -330,7 +330,7 @@ impl ConversionProxy {
                 precision * 10,
             );
         }
-        let main_payment = main_payment * precision / conversion_rate;
+        let main_payment = (main_payment / conversion_rate) * precision;
         return main_payment;
     }
 

--- a/mocks/src/switchboard_feed_parser_mock.rs
+++ b/mocks/src/switchboard_feed_parser_mock.rs
@@ -47,8 +47,8 @@ impl SwitchboardFeedParser {
         match ix.address {
             VALID_FEED_ADDRESS => Some(PriceEntry {
                 result: SwitchboardDecimal {
-                    mantissa: i128::from(1234000),
-                    scale: u8::from(6).into(),
+                    mantissa: i128::from(1234000000),
+                    scale: u8::from(9).into(),
                 },
                 num_success: 1,
                 num_error: 0,
@@ -106,8 +106,8 @@ mod tests {
             address: [0; 32],
             payer: [1; 32],
         }) {
-            assert_eq!(result.result.mantissa, i128::from(1234000));
-            assert_eq!(result.result.scale, 6);
+            assert_eq!(result.result.mantissa, i128::from(1234000000));
+            assert_eq!(result.result.scale, 9);
         } else {
             panic!("NEAR/USD mock returned None")
         }


### PR DESCRIPTION
Conversion induces multiplication of big numbers. The `mantissa` of Switchboard is 9 instead of 6 before, so overflows happen faster.

There are 2 changes in one:
- Small optimization dividing by `ONE_FIAT` (= 100) beforehand.
- `Self::apply_conversion_with_precision`, a recursive util that returns the conversion if it does not overflow or reduce the precision of the conversion.